### PR TITLE
CI: Add Haskell tests to GitHub Actions workflow

### DIFF
--- a/.github/workflows/elm.yml
+++ b/.github/workflows/elm.yml
@@ -1,20 +1,76 @@
-on: push
+name: Projectwide CI checks
+on:
+  pull_request:
+    branches: [ "main" ]
 jobs:
-  elm-check:
+  fe-and-be-checks:
     runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: ./webapp
+
     steps:
     - uses: actions/checkout@v2
-    - run: npm i
-    - name: Add elm-review, elm and elm-format to path
+
+    - name: Setup docker compose (run Postgres DB)
+      uses: yu-ichiro/spin-up-docker-compose-action@v1
+      with:
+        file: ./api/docker-compose.yml
+
+    - name: Install GHC and Cabal
+      uses: haskell/actions/setup@v2
+      id: setup-ghc-cabal
+      with:
+        ghc-version: '9.2.4'
+
+    - name: cabal freeze
+      run: cabal freeze
+      working-directory: ./api
+
+    - name: Restore cache of ~/.cabal/store
+      uses: actions/cache@v2
+      with:
+        path: ${{ steps.setup-ghc-cabal.outputs.cabal-store }}
+        key: ${{ hashFiles('./api/cabal.project.freeze') }}
+
+    - name: Install Haskell dependencies
+      run: |
+        cabal build all --only-dependencies
+      working-directory: ./api
+
+    - name: Build Haskell executables
+      run: |
+        cabal build all
+      working-directory: ./api
+
+    - name: Run Haskell tests
+      run: |
+        cabal test all
+      working-directory: ./api
+
+    - name: Check that Haddocks build properly
+      run: cabal haddock
+      working-directory: ./api
+
+    - name: Install Elm npm deps
+      run: npm i
+      working-directory: ./webapp
+
+    - name: Copy `elm`, `elm-review`, `elm-format` to GitHub PATH
       run: npm bin >> $GITHUB_PATH
-    - uses: sparksp/elm-review-action@v1.0.9
+      working-directory: ./webapp
+
+    - name: Check Elm code is formatted with `elm-format`
+      uses: sparksp/elm-format-action@v1
+      with:
+        elm_files: |
+          ./webapp/src/
+
+    - name: Generate Elm API.elm so that elm-review doesn't think we have unused dependencies (if they're only used in API.elm)
+      run: cabal run metalborn-api-codegen
+      working-directory: ./api
+
+    - name: Check Elm code is linted with `elm-review`
+      uses: sparksp/elm-review-action@v1.0.9
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
        working-directory: ./webapp
-    - uses: sparksp/elm-format-action@v1
-      with: 
-        working-directory: ./webapp
+

--- a/README.md
+++ b/README.md
@@ -24,3 +24,5 @@ The project's frontend is written in Elm, and the API in Haskell.
 Character generation is fully handled by the API server.
 
 Documentation exists for both the Elm and Haskell codebases in [/webapp/](./webapp/) and [/api/](./api/) including how to run locally, techniques and conventions used, endpoint breakdown etc.
+
+There is a [CI pipeline](https://github.com/tam-carre/metalborn/actions/runs/3633421876/jobs/6130418618) that runs Haskell and Elm builds, tests, formatting and linting checks.

--- a/api/.gitignore
+++ b/api/.gitignore
@@ -1,5 +1,3 @@
 dist-newstyle/
 testDescriptions.txt
 Secrets.hs
-./metalborn-api.cabal
-metalborn-api.cabal

--- a/api/README.md
+++ b/api/README.md
@@ -11,15 +11,14 @@ you can change the database connection data in [`src/Config.hs`](./src/Config.hs
 ### Build
 
 Install [GHCup](https://www.haskell.org/ghcup/) and use `ghcup tui` to make sure
-GHC 9.2.4 and Cabal are installed. Then run inside this directory:
+GHC 9.2.4 and Cabal are installed. Then optionally install `hpack`.
 
 ```sh
 cabal update
 cabal install hpack
-hpack
 ```
 
-`hpack` will generate `metalborn-api.cabal` which is not version controlled.
+You'll need to run `hpack` when you edit `package.yaml`, rename a module, or create a new one. It will generate a new `metalborn-api.cabal` file -- the latter is still version controlled so that CI pipelines do not need to install `hpack` which can take a while.
 
 Then run:
 
@@ -49,6 +48,9 @@ You can then check that the database is up and accessible by running:
 ```
 curl -H 'Content-Type: application/json' localhost:8081/api/character/ -d '["Kaladin", "Male"]
 ```
+
+Be aware that you can generate a searchable documentation of the module tree and
+every module's exported functions' types and doc comments by running `cabal haddock`.
 
 ## Project map
 

--- a/api/metalborn-api.cabal
+++ b/api/metalborn-api.cabal
@@ -1,0 +1,324 @@
+cabal-version: 1.12
+
+-- This file has been generated from package.yaml by hpack version 0.35.0.
+--
+-- see: https://github.com/sol/hpack
+
+name:           metalborn-api
+version:        0.1.0.0
+description:    Please see the README on GitHub at <https://github.com/tam-carre/metalborn#readme>
+homepage:       https://github.com/tam-carre/metalborn#readme
+bug-reports:    https://github.com/tam-carre/metalborn/issues
+author:         Tam CARRE
+maintainer:     Tam CARRE
+copyright:      2022 Tam CARRE
+license:        BSD3
+license-file:   LICENSE
+build-type:     Simple
+extra-source-files:
+    README.md
+
+source-repository head
+  type: git
+  location: https://github.com/tam-carre/metalborn
+
+library
+  exposed-modules:
+      App
+      App.Character
+      App.Character.Abilities
+      App.Character.Description
+      App.Character.Metalborn
+      App.Character.Name
+      App.DB
+      App.Docs
+      App.Elm
+      App.Gender
+      App.RNG.Probability
+      App.RNG.Rand
+      App.Server
+      Config
+      Main
+      Prelude
+      REPL
+  other-modules:
+      Paths_metalborn_api
+  hs-source-dirs:
+      src
+  default-extensions:
+      OverloadedStrings
+      OverloadedLabels
+      UnicodeSyntax
+      NoFieldSelectors
+      LambdaCase
+      DuplicateRecordFields
+      ViewPatterns
+      BlockArguments
+      DataKinds
+      TypeOperators
+      TypeFamilies
+  ghc-options: -Wall -Wcompat -Widentities -Wincomplete-record-updates -Wincomplete-uni-patterns -Wmissing-export-lists -Wmissing-home-modules -Wredundant-constraints
+  build-depends:
+      QuickCheck
+    , aeson
+    , base-noprelude
+    , base-unicode-symbols
+    , bytestring
+    , containers
+    , data-default
+    , elm-bridge
+    , extra
+    , generic-lens
+    , hspec
+    , hspec-contrib
+    , http-api-data
+    , http-client
+    , http-conduit
+    , http-types
+    , lens
+    , lens-aeson
+    , mtl
+    , opaleye
+    , postgresql-simple
+    , product-profunctors
+    , profunctors
+    , random
+    , relude
+    , safe-exceptions
+    , scientific
+    , servant
+    , servant-client
+    , servant-docs
+    , servant-elm
+    , servant-foreign
+    , servant-server
+    , template-haskell
+    , text
+    , time
+    , vector
+    , wai
+    , warp
+  default-language: GHC2021
+
+executable metalborn-api-codegen
+  main-is: App/Elm.hs
+  other-modules:
+      App
+      App.Character
+      App.Character.Abilities
+      App.Character.Description
+      App.Character.Metalborn
+      App.Character.Name
+      App.DB
+      App.Docs
+      App.Gender
+      App.RNG.Probability
+      App.RNG.Rand
+      App.Server
+      Config
+      Main
+      Prelude
+      REPL
+      Paths_metalborn_api
+  hs-source-dirs:
+      src
+  default-extensions:
+      OverloadedStrings
+      OverloadedLabels
+      UnicodeSyntax
+      NoFieldSelectors
+      LambdaCase
+      DuplicateRecordFields
+      ViewPatterns
+      BlockArguments
+      DataKinds
+      TypeOperators
+      TypeFamilies
+  ghc-options: -Wall -Wcompat -Widentities -Wincomplete-record-updates -Wincomplete-uni-patterns -Wmissing-export-lists -Wmissing-home-modules -Wredundant-constraints -main-is App.Elm -threaded -rtsopts -with-rtsopts=-N -fwrite-ide-info
+  build-depends:
+      QuickCheck
+    , aeson
+    , base-noprelude
+    , base-unicode-symbols
+    , bytestring
+    , containers
+    , data-default
+    , elm-bridge
+    , extra
+    , generic-lens
+    , hspec
+    , hspec-contrib
+    , http-api-data
+    , http-client
+    , http-conduit
+    , http-types
+    , lens
+    , lens-aeson
+    , metalborn-api
+    , mtl
+    , opaleye
+    , postgresql-simple
+    , product-profunctors
+    , profunctors
+    , random
+    , relude
+    , safe-exceptions
+    , scientific
+    , servant
+    , servant-client
+    , servant-docs
+    , servant-elm
+    , servant-foreign
+    , servant-server
+    , template-haskell
+    , text
+    , time
+    , vector
+    , wai
+    , warp
+  default-language: GHC2021
+
+executable metalborn-api-exe
+  main-is: Main.hs
+  other-modules:
+      App
+      App.Character
+      App.Character.Abilities
+      App.Character.Description
+      App.Character.Metalborn
+      App.Character.Name
+      App.DB
+      App.Docs
+      App.Elm
+      App.Gender
+      App.RNG.Probability
+      App.RNG.Rand
+      App.Server
+      Config
+      Prelude
+      REPL
+      Paths_metalborn_api
+  hs-source-dirs:
+      src
+  default-extensions:
+      OverloadedStrings
+      OverloadedLabels
+      UnicodeSyntax
+      NoFieldSelectors
+      LambdaCase
+      DuplicateRecordFields
+      ViewPatterns
+      BlockArguments
+      DataKinds
+      TypeOperators
+      TypeFamilies
+  ghc-options: -Wall -Wcompat -Widentities -Wincomplete-record-updates -Wincomplete-uni-patterns -Wmissing-export-lists -Wmissing-home-modules -Wredundant-constraints -threaded -rtsopts -with-rtsopts=-N -fwrite-ide-info
+  build-depends:
+      QuickCheck
+    , aeson
+    , base-noprelude
+    , base-unicode-symbols
+    , bytestring
+    , containers
+    , data-default
+    , elm-bridge
+    , extra
+    , generic-lens
+    , hspec
+    , hspec-contrib
+    , http-api-data
+    , http-client
+    , http-conduit
+    , http-types
+    , lens
+    , lens-aeson
+    , metalborn-api
+    , mtl
+    , opaleye
+    , postgresql-simple
+    , product-profunctors
+    , profunctors
+    , random
+    , relude
+    , safe-exceptions
+    , scientific
+    , servant
+    , servant-client
+    , servant-docs
+    , servant-elm
+    , servant-foreign
+    , servant-server
+    , template-haskell
+    , text
+    , time
+    , vector
+    , wai
+    , warp
+  default-language: GHC2021
+
+test-suite metalborn-api-test
+  type: exitcode-stdio-1.0
+  main-is: Spec.hs
+  other-modules:
+      CharacterAbilitiesSpec
+      CharacterDescriptionSpec
+      DBSpec
+      Paths_metalborn_api
+  hs-source-dirs:
+      test
+  default-extensions:
+      OverloadedStrings
+      OverloadedLabels
+      UnicodeSyntax
+      NoFieldSelectors
+      LambdaCase
+      DuplicateRecordFields
+      ViewPatterns
+      BlockArguments
+      DataKinds
+      TypeOperators
+      TypeFamilies
+  ghc-options: -Wall -Wcompat -Widentities -Wincomplete-record-updates -Wincomplete-uni-patterns -Wmissing-export-lists -Wmissing-home-modules -Wredundant-constraints -threaded -rtsopts -with-rtsopts=-N
+  build-depends:
+      QuickCheck
+    , aeson
+    , base-noprelude
+    , base-unicode-symbols
+    , bytestring
+    , containers
+    , data-default
+    , elm-bridge
+    , extra
+    , generic-lens
+    , hspec
+    , hspec-contrib
+    , http-api-data
+    , http-client
+    , http-conduit
+    , http-types
+    , lens
+    , lens-aeson
+    , metalborn-api
+    , mtl
+    , opaleye
+    , postgresql-simple
+    , product-profunctors
+    , profunctors
+    , random
+    , relude
+    , safe-exceptions
+    , scientific
+    , servant
+    , servant-client
+    , servant-docs
+    , servant-elm
+    , servant-foreign
+    , servant-server
+    , template-haskell
+    , text
+    , time
+    , vector
+    , wai
+    , warp
+  default-language: GHC2021
+  build-tool-depends: hspec-discover:hspec-discover == 2.*

--- a/api/package.yaml
+++ b/api/package.yaml
@@ -93,9 +93,24 @@ executables:
     dependencies:
     - metalborn-api
 
+  metalborn-api-codegen:
+    main:                App/Elm.hs
+    source-dirs:         src
+    ghc-options:
+    - -main-is App.Elm
+    - -threaded
+    - -rtsopts
+    - -with-rtsopts=-N
+    - -fwrite-ide-info
+    dependencies:
+    - metalborn-api
+
 tests:
   metalborn-api-test:
     main:                Spec.hs
+    verbatim:
+      build-tool-depends:
+        hspec-discover:hspec-discover == 2.*
     source-dirs:         test
     ghc-options:
     - -threaded

--- a/api/src/App/Elm.hs
+++ b/api/src/App/Elm.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE AllowAmbiguousTypes, ScopedTypeVariables #-}
 
-module App.Elm (generateElmCode) where
+module App.Elm (main, generateElmCode) where
 
 import App.Character             (Character)
 import App.Character.Abilities   (Abilities, AbilitiesObtained, AbilityProbabilities)
@@ -15,6 +15,9 @@ import Elm.TyRep                 (IsElmDefinition)
 import Servant.Elm               (DefineElm (..), defElmImports, generateElmModule)
 
 ----------------------------------------------------------------------------------------------------
+
+main ∷ IO ()
+main = generateElmCode
 
 generateElmCode ∷ IO ()
 generateElmCode = generateElmModule [ "API" ] defElmImports "../webapp/src" sharedTypes siteAPI

--- a/api/test/DBSpec.hs
+++ b/api/test/DBSpec.hs
@@ -8,7 +8,6 @@ import App.Character.Metalborn   (Ferring (..), Halfborn (..), Metal (..), Metal
 import App.Character.Name        (Name (Name))
 import App.DB                    qualified as DB
 import App.Gender                (Gender (Male))
-import Secrets qualified
 import Test.Hspec                (Spec, beforeAll, it, shouldBe)
 
 ----------------------------------------------------------------------------------------------------
@@ -17,7 +16,7 @@ import Test.Hspec                (Spec, beforeAll, it, shouldBe)
 -- If one fails, the remaining ones will not be run.
 spec ∷ Spec
 spec = beforeAll (newIORef PreviousTestsSuccessful) do
-  let dummyName   = Name Secrets.dummyCharacterName
+  let dummyName   = Name "TEST_CHARACTER_NAME_FSWTRCRSPTWF"
       dummyGender = Male
       dummyBlocks = [AllomancyBlock "dummy allo", FeruchemyBlock "dummy feru"]
       dummyAbils  = Abilities (Just . Halfborn . Mistborn $ Just Skimmer)

--- a/webapp/review/src/ReviewConfig.elm
+++ b/webapp/review/src/ReviewConfig.elm
@@ -54,9 +54,7 @@ config =
     , NoPrematureLetComputation.rule
     , NoUnused.CustomTypeConstructors.rule []
     , NoUnused.CustomTypeConstructorArgs.rule
-
-    -- Turn this back on when the CI pipeline generates API.elm
-    -- , NoUnused.Dependencies.rule
+    , NoUnused.Dependencies.rule
     , NoUnused.Exports.rule
     , NoUnused.Parameters.rule
     , NoUnused.Patterns.rule


### PR DESCRIPTION
- Add to the GitHub Action pipeline Haskell tests and build
- Use the Haskell code generator for Elm in the pipeline so I can turn back on the elm-review rule `NoUnused.Dependencies` which didn't see dependencies being used in `API.elm`
- Note that the `elm-format` check must be run before the code generator as its output is non formatted and I couldn't get the GitHub Action to ignore `API.elm`.
- The codegen has been made its own executable but is still also run every time the API server is launched
- `metalborn-api.cabal` is version controlled again to not have to build `hpack` in the CI pipeline
- The root `README.md` file has been updated with some info on the CI pipeline.

CI Pipeline takes 18 minutes if Haskell dependencies have changed; 4 minutes if they didn't.